### PR TITLE
Hotfix/issue234 Added Unit Test for Hardware Encoding

### DIFF
--- a/Samples/Server/NativeServersUnitTests/NativeServersTests.cpp
+++ b/Samples/Server/NativeServersUnitTests/NativeServersTests.cpp
@@ -33,6 +33,9 @@ namespace NativeServersUnitTests
 			delete encoder;
 		}
 
+		BEGIN_TEST_METHOD_ATTRIBUTE(HasCompatibleGPUAndDriver)
+		TEST_METHOD_ATTRIBUTE(L"Priority", "2")
+		END_TEST_METHOD_ATTRIBUTE()
 		TEST_METHOD(HasCompatibleGPUAndDriver)
 		{
 			HRESULT hres;
@@ -173,6 +176,9 @@ namespace NativeServersUnitTests
 			VariantClear(&driverNumber);
 		}
 
+		BEGIN_TEST_METHOD_ATTRIBUTE(HardwareEncodingIsEnabled)
+		TEST_METHOD_ATTRIBUTE(L"Priority", "2")
+		END_TEST_METHOD_ATTRIBUTE()
 		TEST_METHOD(HardwareEncodingIsEnabled) {
 			//Using default settings from webrtc documentation
 			const nvpipe_codec codec = NVPIPE_H264_NV;


### PR DESCRIPTION
## Checklist
***This checklist is used to make sure that common guidelines for a pull request are followed.***

- [X ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] If applicable, the code is properly documented.
- [X] The code builds without any errors.
- [X] All unit and integration tests pass.

## Description
This fixes the problem with #234 and adds a working hardware encoder test using nvpipe. The previous test was broken because it only checked to see whether a frame could be correctly encoded, but the webrtc framework does the encoding implicitly, using hardware or software encoding depending on whichever is available.

This test actually ensures that hardware encoding is enabled and compatible. 

## Related Issues and PRs
Issue #234 
