### PR TITLE
Updates to Powershell install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,6 +261,8 @@ Libraries/glext
 *.log
 *.cso
 *.zip
+*.zip.partial
+*.zip.version
 js-3dtoolkit.*
 sdputils.*
 

--- a/Libraries/DirectXTK/InstallLibraries.ps1
+++ b/Libraries/DirectXTK/InstallLibraries.ps1
@@ -1,121 +1,37 @@
-Import-Module BitsTransfer
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-function Get-ScriptDirectory
-{
-  $Invocation = (Get-Variable MyInvocation -Scope 1).Value
-  Split-Path $Invocation.MyCommand.Path
-}
+. ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
     param( [string] $filename, [string] $blobUri = "https://3dtoolkitstorage.blob.core.windows.net/libs/" )
     
+    # Get ETag header for current blob
     $uri = ($blobUri + $filename + ".zip")
-    $request = [System.Net.HttpWebRequest]::Create($uri)
-    $request.Timeout = 10000
-    $response = $request.GetResponse()
-    $etag = $response.Headers["ETag"] 
-    $request.Abort()
-    $localFileName = ($filename + ".zip")
+    $etag = Get-ETag -Uri $uri
+    $localFileName = ($filename + $etag + ".zip")
     $localFullPath = ($PSScriptRoot + "\" + $localFileName)
     
-    Get-ChildItem -File -Path $PSScriptRoot -Filter ("*" + $filename + "*") | ForEach-Object { #
-        if($_.Name -notmatch (".*" + $etag + ".*")) {
-                Write-Host "Removing outdated lib"
-                Remove-Item * -Include $_.Name
-        }
-    }
+    # If the library with the current ETag does not exist 
+    if ((Test-Path ($localFullPath)) -eq $false) {
 
-    if((Test-Path ($PSScriptRoot + "\Win32")) -eq $false) {
-        Write-Host ("Downloading " + $filename + " lib archive")
-        if((Test-Path ($localFullPath)) -eq $false) {
-               Copy-File -SourcePath $uri -DestinationPath $localFullPath    
-               Write-Host ("Downloaded " + $filename + " lib archive")
+        # Clear the files from the previous library version
+        Write-Host "Clearing the existing $filename library"
+        Get-ChildItem -Path $PSScriptRoot | ForEach-Object {
+            $scriptName = [System.IO.Path]::GetFileName($PSCommandPath)
+            if ($_.Name -ne $localFileName -and $_.Name -ne $scriptName) {
+                Remove-Item -Recurse -Force ($PSScriptRoot + "\" + $_.Name)
+            }
         }
+
+                # Download the library
+        Write-Host "Downloading $filename from $uri"
+        Copy-File -SourcePath $uri -DestinationPath $localFullPath    
+        Write-Host ("Downloaded " + $filename + " lib archive")
+
+
+        # Extract the latest library
         Write-Host "Extracting..."
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
+        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot
         Write-Host "Finished"
     }
-}
-
-function
-Copy-File
-{
-    [CmdletBinding()]
-    param(
-        [string]
-        $SourcePath,
-        
-        [string]
-        $DestinationPath
-    )
-    
-    if ($SourcePath -eq $DestinationPath)
-    {
-        return
-    }
-          
-    if (Test-Path $SourcePath)
-    {
-        Copy-Item -Path $SourcePath -Destination $DestinationPath
-    }
-    elseif (($SourcePath -as [System.URI]).AbsoluteURI -ne $null)
-    {
-        if (Test-Nano)
-        {
-            $handler = New-Object System.Net.Http.HttpClientHandler
-            $client = New-Object System.Net.Http.HttpClient($handler)
-            $client.Timeout = New-Object System.TimeSpan(0, 30, 0)
-            $cancelTokenSource = [System.Threading.CancellationTokenSource]::new() 
-            $responseMsg = $client.GetAsync([System.Uri]::new($SourcePath), $cancelTokenSource.Token)
-            $responseMsg.Wait()
-
-            if (!$responseMsg.IsCanceled)
-            {
-                $response = $responseMsg.Result
-                if ($response.IsSuccessStatusCode)
-                {
-                    $downloadedFileStream = [System.IO.FileStream]::new($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
-                    $copyStreamOp = $response.Content.CopyToAsync($downloadedFileStream)
-                    $copyStreamOp.Wait()
-                    $downloadedFileStream.Close()
-                    if ($copyStreamOp.Exception -ne $null)
-                    {
-                        throw $copyStreamOp.Exception
-                    }      
-                }
-            }  
-        }
-        elseif ($PSVersionTable.PSVersion.Major -ge 5)
-        {
-            #
-            # We disable progress display because it kills performance for large downloads (at least on 64-bit PowerShell)
-            #
-            $ProgressPreference = 'SilentlyContinue'
-            wget -Uri $SourcePath -OutFile $DestinationPath -UseBasicParsing
-            $ProgressPreference = 'Continue'
-        }
-        else
-        {
-            $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile($SourcePath, $DestinationPath)
-        } 
-    }
-    else
-    {
-        throw "Cannot copy from $SourcePath"
-    }
-}
-
-function 
-Test-Nano()
-{
-    $EditionId = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name 'EditionID').EditionId
-
-    return (($EditionId -eq "ServerStandardNano") -or 
-            ($EditionId -eq "ServerDataCenterNano") -or 
-            ($EditionId -eq "NanoServer") -or 
-            ($EditionId -eq "ServerTuva"))
 }
 
 DecompressZip -filename "libDirectXTK"

--- a/Libraries/DirectXTK/InstallLibraries.ps1
+++ b/Libraries/DirectXTK/InstallLibraries.ps1
@@ -1,3 +1,5 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 . ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
@@ -29,7 +31,8 @@ function DecompressZip {
 
         # Extract the latest library
         Write-Host "Extracting..."
-        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot
+        # ExtractToDirectory is at least 3x faster than Expand-Archive
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
         Write-Host "Finished"
 
         # Clean up .zip file

--- a/Libraries/Nvpipe/InstallLibraries.ps1
+++ b/Libraries/Nvpipe/InstallLibraries.ps1
@@ -1,23 +1,15 @@
-Import-Module BitsTransfer
-
-function Get-ScriptDirectory
-{
-  $Invocation = (Get-Variable MyInvocation -Scope 1).Value
-  Split-Path $Invocation.MyCommand.Path
-}
+. ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
     param( [string] $filename, [string] $blobUri = "https://3dtoolkitstorage.blob.core.windows.net/libs/" )
     
+    # Get ETag header for current blob
     $uri = ($blobUri + $filename + ".zip")
-    $request = [System.Net.HttpWebRequest]::Create($uri)
-    $request.Timeout = 10000
-    $response = $request.GetResponse()
-    $etag = $response.Headers["ETag"] 
-    $request.Abort()
-    $localFileName = ($filename + ".zip")
+    $etag = Get-ETag -Uri $uri
+    $localFileName = ($filename + $etag + ".zip")
     $localFullPath = ($PSScriptRoot + "\" + $localFileName)
     
+    # Check if the library with the current ETag already exists
     Get-ChildItem -File -Path $PSScriptRoot -Filter ("*" + $filename + "*") | ForEach-Object { #
         if($_.Name -notmatch (".*" + $etag + ".*")) {
                 Write-Host "Removing outdated lib"
@@ -25,96 +17,28 @@ function DecompressZip {
         }
     }
 
-    if((Test-Path ($PSScriptRoot + "\Win32")) -eq $false) {
-        Write-Host ("Downloading " + $filename + " lib archive")
-        if((Test-Path ($localFullPath)) -eq $false) {
-               Copy-File -SourcePath $uri -DestinationPath $localFullPath    
-               Write-Host ("Downloaded " + $filename + " lib archive")
+    # If the library with the current ETag does not exist 
+    if ((Test-Path ($localFullPath)) -eq $false) {
+
+        # Download the library
+        Write-Host "Downloading $filename from $uri"
+        Copy-File -SourcePath $uri -DestinationPath $localFullPath    
+        Write-Host ("Downloaded " + $filename + " lib archive")
+
+        # Clear the files from the previous library version
+        Write-Host "Clearing the existing $filename library"
+        Get-ChildItem -Path $PSScriptRoot | ForEach-Object {
+            $scriptName = [System.IO.Path]::GetFileName($PSCommandPath)
+            if ($_.Name -ne $localFileName -and $_.Name -ne $scriptName) {
+                Remove-Item -Recurse -Force ($PSScriptRoot + "\" + $_.Name)
+            }
         }
+
+        # Extract the latest library
         Write-Host "Extracting..."
-        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot -Force
+        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot
         Write-Host "Finished"
     }
-}
-
-function
-Copy-File
-{
-    [CmdletBinding()]
-    param(
-        [string]
-        $SourcePath,
-        
-        [string]
-        $DestinationPath
-    )
-    
-    if ($SourcePath -eq $DestinationPath)
-    {
-        return
-    }
-          
-    if (Test-Path $SourcePath)
-    {
-        Copy-Item -Path $SourcePath -Destination $DestinationPath
-    }
-    elseif (($SourcePath -as [System.URI]).AbsoluteURI -ne $null)
-    {
-        if (Test-Nano)
-        {
-            $handler = New-Object System.Net.Http.HttpClientHandler
-            $client = New-Object System.Net.Http.HttpClient($handler)
-            $client.Timeout = New-Object System.TimeSpan(0, 30, 0)
-            $cancelTokenSource = [System.Threading.CancellationTokenSource]::new() 
-            $responseMsg = $client.GetAsync([System.Uri]::new($SourcePath), $cancelTokenSource.Token)
-            $responseMsg.Wait()
-
-            if (!$responseMsg.IsCanceled)
-            {
-                $response = $responseMsg.Result
-                if ($response.IsSuccessStatusCode)
-                {
-                    $downloadedFileStream = [System.IO.FileStream]::new($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
-                    $copyStreamOp = $response.Content.CopyToAsync($downloadedFileStream)
-                    $copyStreamOp.Wait()
-                    $downloadedFileStream.Close()
-                    if ($copyStreamOp.Exception -ne $null)
-                    {
-                        throw $copyStreamOp.Exception
-                    }      
-                }
-            }  
-        }
-        elseif ($PSVersionTable.PSVersion.Major -ge 5)
-        {
-            #
-            # We disable progress display because it kills performance for large downloads (at least on 64-bit PowerShell)
-            #
-            $ProgressPreference = 'SilentlyContinue'
-            wget -Uri $SourcePath -OutFile $DestinationPath -UseBasicParsing
-            $ProgressPreference = 'Continue'
-        }
-        else
-        {
-            $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile($SourcePath, $DestinationPath)
-        } 
-    }
-    else
-    {
-        throw "Cannot copy from $SourcePath"
-    }
-}
-
-function 
-Test-Nano()
-{
-    $EditionId = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name 'EditionID').EditionId
-
-    return (($EditionId -eq "ServerStandardNano") -or 
-            ($EditionId -eq "ServerDataCenterNano") -or 
-            ($EditionId -eq "NanoServer") -or 
-            ($EditionId -eq "ServerTuva"))
 }
 
 DecompressZip -filename "Nvpipe"

--- a/Libraries/Nvpipe/InstallLibraries.ps1
+++ b/Libraries/Nvpipe/InstallLibraries.ps1
@@ -1,3 +1,5 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 . ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
@@ -29,7 +31,8 @@ function DecompressZip {
 
         # Extract the latest library
         Write-Host "Extracting..."
-        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot
+        # ExtractToDirectory is at least 3x faster than Expand-Archive
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
         Write-Host "Finished"
 
         # Clean up .zip file

--- a/Libraries/Nvpipe/InstallLibraries.ps1
+++ b/Libraries/Nvpipe/InstallLibraries.ps1
@@ -1,5 +1,4 @@
 Import-Module BitsTransfer
-Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 function Get-ScriptDirectory
 {
@@ -33,7 +32,7 @@ function DecompressZip {
                Write-Host ("Downloaded " + $filename + " lib archive")
         }
         Write-Host "Extracting..."
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
+        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot -Force
         Write-Host "Finished"
     }
 }

--- a/Libraries/WebRTC/webrtcInstallLibs.ps1
+++ b/Libraries/WebRTC/webrtcInstallLibs.ps1
@@ -1,33 +1,26 @@
-Import-Module BitsTransfer
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-function Get-ScriptDirectory
-{
-  $Invocation = (Get-Variable MyInvocation -Scope 1).Value
-  Split-Path $Invocation.MyCommand.Path
-}
+. ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
     param( [string] $filename, [string] $blobUri = "https://3dtoolkitstorage.blob.core.windows.net/libs/" )
     
+    # Get ETag header for current blob
     $uri = ($blobUri + $filename + ".zip")
-    $request = [System.Net.HttpWebRequest]::Create($uri)
-    $request.Timeout = 10000
-    $response = $request.GetResponse()
-    $etag = $response.Headers["ETag"] 
-    $request.Abort()
+    $etag = Get-ETag -Uri $uri
     $localFileName = ($filename + $etag + ".zip")
     $localFullPath = ($PSScriptRoot + "\" + $localFileName)
     
+    # Clear previous versions of the library
     Get-ChildItem -File -Path $PSScriptRoot -Filter ("*" + $filename + "*") | ForEach-Object { #
         if($_.Name -notmatch (".*" + $etag + ".*")) {
-                Write-Host "Removing outdated lib"
-                Remove-Item * -Include $_.Name
+            Write-Host "Removing outdated lib"
+            Remove-Item * -Include $_.Name
         }
     }
 
-    if((Test-Path ($localFullPath)) -eq $false) {
+    # If the library with the current ETag does not exist 
+    if ((Test-Path ($localFullPath)) -eq $false) {
 
+        # Download the library
         Write-Host "Downloading $localFileName from $uri"
         Copy-File -SourcePath $uri -DestinationPath $localFullPath    
         Write-Host ("Downloaded " + $filename + " lib archive")
@@ -47,95 +40,17 @@ function DecompressZip {
             return
         }
         
+        # Clear the files from the previous library version
         if((Test-Path ($PSScriptRoot + $extractDir)) -eq $true) {
             Write-Host "Clearing existing $extractDir" 
             Remove-Item -Recurse -Force ($PSScriptRoot + $extractDir)
         }
 
+        # Extract the latest library
         Write-Host "Extracting..."
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
+        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot
         Write-Host "Finished"
     }
-}
-
-function
-Copy-File
-{
-    [CmdletBinding()]
-    param(
-        [string]
-        $SourcePath,
-        
-        [string]
-        $DestinationPath
-    )
-    
-    if ($SourcePath -eq $DestinationPath)
-    {
-        return
-    }
-          
-    if (Test-Path $SourcePath)
-    {
-        Copy-Item -Path $SourcePath -Destination $DestinationPath
-    }
-    elseif (($SourcePath -as [System.URI]).AbsoluteURI -ne $null)
-    {
-        if (Test-Nano)
-        {
-            $handler = New-Object System.Net.Http.HttpClientHandler
-            $client = New-Object System.Net.Http.HttpClient($handler)
-            $client.Timeout = New-Object System.TimeSpan(0, 30, 0)
-            $cancelTokenSource = [System.Threading.CancellationTokenSource]::new() 
-            $responseMsg = $client.GetAsync([System.Uri]::new($SourcePath), $cancelTokenSource.Token)
-            $responseMsg.Wait()
-
-            if (!$responseMsg.IsCanceled)
-            {
-                $response = $responseMsg.Result
-                if ($response.IsSuccessStatusCode)
-                {
-                    $downloadedFileStream = [System.IO.FileStream]::new($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
-                    $copyStreamOp = $response.Content.CopyToAsync($downloadedFileStream)
-                    $copyStreamOp.Wait()
-                    $downloadedFileStream.Close()
-                    if ($copyStreamOp.Exception -ne $null)
-                    {
-                        throw $copyStreamOp.Exception
-                    }      
-                }
-            }  
-        }
-        elseif ($PSVersionTable.PSVersion.Major -ge 5)
-        {
-            #
-            # We disable progress display because it kills performance for large downloads (at least on 64-bit PowerShell)
-            #
-            $ProgressPreference = 'SilentlyContinue'
-            wget -Uri $SourcePath -OutFile $DestinationPath -UseBasicParsing
-            $ProgressPreference = 'Continue'
-        }
-        else
-        {
-            $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile($SourcePath, $DestinationPath)
-        } 
-    }
-    else
-    {
-        throw "Cannot copy from $SourcePath"
-    }
-}
-
-function 
-Test-Nano()
-{
-    $EditionId = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name 'EditionID').EditionId
-
-    return (($EditionId -eq "ServerStandardNano") -or 
-            ($EditionId -eq "ServerDataCenterNano") -or 
-            ($EditionId -eq "NanoServer") -or 
-            ($EditionId -eq "ServerTuva"))
 }
 
 DecompressZip -filename "m62patch_nvpipe_headers"

--- a/Libraries/WebRTC/webrtcInstallLibs.ps1
+++ b/Libraries/WebRTC/webrtcInstallLibs.ps1
@@ -1,3 +1,5 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 . ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
@@ -40,7 +42,8 @@ function DecompressZip {
 
         # Extract the latest library
         Write-Host "Extracting..."
-        Expand-Archive -Path $localFullPath -DestinationPath $PSScriptRoot
+        # ExtractToDirectory is at least 3x faster than Expand-Archive
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
         Write-Host "Finished"
 
         # Clean up .zip file

--- a/Libraries/WebRTCUWP/InstallLibraries.ps1
+++ b/Libraries/WebRTCUWP/InstallLibraries.ps1
@@ -1,19 +1,10 @@
-Import-Module BitsTransfer
-Add-Type -AssemblyName System.IO.Compression.FileSystem
+. ../../Utilities/InstallLibraries.ps1
 
-function Get-ScriptDirectory
-{
-  $Invocation = (Get-Variable MyInvocation -Scope 1).Value
-  Split-Path $Invocation.MyCommand.Path
-}
 function DecompressZip {
     param( [string] $filename, [string] $path, [string] $blobUri = "https://3dtoolkitstorage.blob.core.windows.net/libs/" )
+
     $uri = ($blobUri + $filename + ".zip")
-    $request = [System.Net.HttpWebRequest]::Create($uri)
-    $request.Timeout = 10000
-    $response = $request.GetResponse()
-    $etag = $response.Headers["ETag"] 
-    $request.Abort()
+    $etag = Get-ETag -Uri $uri
     $localFileName = ($filename + $etag + ".zip")
     $localFullPath = ($PSScriptRoot +  $path + $localFileName)
     $libRemoved = $false
@@ -52,88 +43,8 @@ function DecompressZip {
     Write-Host ("Downloaded " + $filename + " lib archive")
 
     Write-Host "Extracting..."
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, ($PSScriptRoot + $path))
+    Expand-Archive -Path $localFullPath -DestinationPath ($PSScriptRoot + $path)
     Write-Host "Finished"
-}
-
-function
-Copy-File
-{
-    [CmdletBinding()]
-    param(
-        [string]
-        $SourcePath,
-        
-        [string]
-        $DestinationPath
-    )
-    
-    if ($SourcePath -eq $DestinationPath)
-    {
-        return
-    }
-          
-    if (Test-Path $SourcePath)
-    {
-        Copy-Item -Path $SourcePath -Destination $DestinationPath
-    }
-    elseif (($SourcePath -as [System.URI]).AbsoluteURI -ne $null)
-    {
-        if (Test-Nano)
-        {
-            $handler = New-Object System.Net.Http.HttpClientHandler
-            $client = New-Object System.Net.Http.HttpClient($handler)
-            $client.Timeout = New-Object System.TimeSpan(0, 30, 0)
-            $cancelTokenSource = [System.Threading.CancellationTokenSource]::new() 
-            $responseMsg = $client.GetAsync([System.Uri]::new($SourcePath), $cancelTokenSource.Token)
-            $responseMsg.Wait()
-
-            if (!$responseMsg.IsCanceled)
-            {
-                $response = $responseMsg.Result
-                if ($response.IsSuccessStatusCode)
-                {
-                    $downloadedFileStream = [System.IO.FileStream]::new($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
-                    $copyStreamOp = $response.Content.CopyToAsync($downloadedFileStream)
-                    $copyStreamOp.Wait()
-                    $downloadedFileStream.Close()
-                    if ($copyStreamOp.Exception -ne $null)
-                    {
-                        throw $copyStreamOp.Exception
-                    }      
-                }
-            }  
-        }
-        elseif ($PSVersionTable.PSVersion.Major -ge 5)
-        {
-            #
-            # We disable progress display because it kills performance for large downloads (at least on 64-bit PowerShell)
-            #
-            $ProgressPreference = 'SilentlyContinue'
-            wget -Uri $SourcePath -OutFile $DestinationPath -UseBasicParsing
-            $ProgressPreference = 'Continue'
-        }
-        else
-        {
-            $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile($SourcePath, $DestinationPath)
-        } 
-    }
-    else
-    {
-        throw "Cannot copy from $SourcePath"
-    }
-}
-
-function 
-Test-Nano()
-{
-    $EditionId = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name 'EditionID').EditionId
-
-    return (($EditionId -eq "ServerStandardNano") -or 
-            ($EditionId -eq "ServerDataCenterNano") -or 
-            ($EditionId -eq "NanoServer") -or 
-            ($EditionId -eq "ServerTuva"))
 }
 
 DecompressZip -filename "Org.WebRtc_m62_timestamp_v1" -path "\Org.WebRTC\"

--- a/Libraries/WebRTCUWP/InstallLibraries.ps1
+++ b/Libraries/WebRTCUWP/InstallLibraries.ps1
@@ -1,3 +1,5 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 . ../../Utilities/InstallLibraries.ps1
 
 function DecompressZip {
@@ -42,7 +44,8 @@ function DecompressZip {
 
         # Extract the latest library
         Write-Host "Extracting..."
-        Expand-Archive -Path $localFullPath -DestinationPath ($PSScriptRoot + $path)
+        # ExtractToDirectory is at least 3x faster than Expand-Archive
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
         Write-Host "Finished"
 
         # Clean up .zip file

--- a/Utilities/InstallLibraries.ps1
+++ b/Utilities/InstallLibraries.ps1
@@ -95,3 +95,32 @@ function Get-ETag {
     $request.Abort()
     return $etag
 }
+
+function Compare-Version {
+    param(
+        [string]
+        $Version,
+
+        [string]
+        $Path
+    )
+
+    $versionPath = $Path + ".version"
+    if ((Test-Path ($versionPath)) -eq $false) {
+        return $false
+    } 
+    
+    return [System.IO.File]::ReadAllText($versionPath) -eq $ETag
+}
+
+function Write-Version {
+    param(
+        [string]
+        $Path,
+
+        [string]
+        $Version
+    )
+
+    [System.IO.File]::WriteAllText($Path + ".version", $ETag)
+}

--- a/Utilities/InstallOpenGL.ps1
+++ b/Utilities/InstallOpenGL.ps1
@@ -1,0 +1,30 @@
+. .\InstallLibraries.ps1
+
+function DecompressZip {
+    param( [string] $filename, [string] $blobUri = "https://3dtoolkitstorage.blob.core.windows.net/libs/" )
+    
+    $uri = ($blobUri + $filename + ".zip")
+    $etag = Get-ETag -Uri $uri
+    $localFileName = ($filename + $etag + ".zip")
+    $localFullPath = ($PSScriptRoot + "\..\Libraries\" + $localFileName)
+    
+    Get-ChildItem -File -Path $PSScriptRoot -Filter ("*" + $filename + "*") | ForEach-Object { #
+        if($_.Name -notmatch (".*" + $etag + ".*")) {
+                Write-Host "Removing outdated lib"
+                Remove-Item * -Include $_.Name
+        }
+    }
+
+    if((Test-Path ($PSScriptRoot + "\..\Libraries\Freeglut")) -eq $false) {
+        Write-Host ("Downloading " + $filename + " lib archive")
+        if((Test-Path ($localFullPath)) -eq $false) {
+               Copy-File -SourcePath $uri -DestinationPath $localFullPath    
+               Write-Host ("Downloaded " + $filename + " lib archive")
+        }
+        Write-Host "Extracting..."
+        Expand-Archive -Path $localFullPath -DestinationPath ($PSScriptRoot + "\..\Libraries\")
+        Write-Host "Finished"
+    }
+}
+
+DecompressZip -filename "libOpenGL"

--- a/Utilities/InstallOpenGL.ps1
+++ b/Utilities/InstallOpenGL.ps1
@@ -1,3 +1,5 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 . .\InstallLibraries.ps1
 
 function DecompressZip {
@@ -30,7 +32,8 @@ function DecompressZip {
 
         # Extract the latest library
         Write-Host "Extracting..."
-        Expand-Archive -Path $localFullPath -DestinationPath ($PSScriptRoot + "\..\Libraries\")
+        # ExtractToDirectory is at least 3x faster than Expand-Archive
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($localFullPath, $PSScriptRoot)
         Write-Host "Finished"
 
         # Clean up .zip file

--- a/Utilities/setup.ps1
+++ b/Utilities/setup.ps1
@@ -62,7 +62,7 @@ Write-Host 'Finished Library '$libCount'/'$libTotal
 Set-Location -Path ($PSScriptRoot)
 
 try {
-    & .\InstallLibraries.ps1
+    & .\InstallOpenGL.ps1
 } catch {
     $err = $_.Exception
 }
@@ -70,6 +70,9 @@ try {
 if ($err) {
     Write-Host ('Error retrieving OpenGL libraries for OpenGL sample server: ' + $err.Message) -ForegroundColor Red
 }
+
+$libCount++
+Write-Host 'Finished Library '$libCount'/'$libTotal
 
 if ($err -eq $null) {
     Write-Host 'Libraries retrieved and up to date' -ForegroundColor Green


### PR DESCRIPTION
The System.IO.Compression.ZipFile.ExtractToDirectory helper does not support overwriting existing files, so running `Libraries\Nvpipe\InstallLibraries.ps1` results in an exception. Using the Powershell command `Extract-Archive` with the `-Force` option allows overwrite.

This work is towards #237, but there is a larger remaining issue that the `Nvpipe` download always occurs, even if an update isn't necessary.

## Checklist
***This checklist is used to make sure that common guidelines for a pull request are followed.***

- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] If applicable, the code is properly documented.
- [x] The code builds without any errors.
- [x] All unit and integration tests pass.

## Description
***Please add an informative description that covers the changes made by the pull request.***

The System.IO.Compression.ZipFile.ExtractToDirectory helper does not support overwriting existing files, so running `Libraries\Nvpipe\InstallLibraries.ps1` resulted in an exception. These updates ensure, when an updated library is made available, the previous directories are cleaned up. It also removes the need to persist the rather large .zip files.

## Related Issues and PRs
***Please provide a reference to an [existing issue](https://github.com/CatalystCode/3dtoolkit/issues) and any related pull requests.***

Fixes #237