### PR TITLE
Use Assert::AreEqual to improve failure messages

### DIFF
--- a/Libraries/ConfigParser/ConfigParser.Tests/ConfigParserTests.cpp
+++ b/Libraries/ConfigParser/ConfigParser.Tests/ConfigParserTests.cpp
@@ -58,8 +58,8 @@ namespace ConfigParserTests
 			Assert::AreEqual("test", injectedWebRTCInstance->turn_server.username.c_str());
 			Assert::AreEqual("test", injectedWebRTCInstance->turn_server.password.c_str());
 			Assert::AreEqual("testUri", injectedWebRTCInstance->server_uri.c_str());
-			Assert::IsTrue(((uint16_t)5678) == injectedWebRTCInstance->port);
-			Assert::IsTrue(((uint32_t)91011) == injectedWebRTCInstance->heartbeat);
+			Assert::AreEqual(((uint16_t)5678), injectedWebRTCInstance->port);
+			Assert::AreEqual(((uint32_t)91011), injectedWebRTCInstance->heartbeat);
 			Assert::AreEqual("test:test:1234", injectedWebRTCInstance->stun_server.uri.c_str());
 			Assert::AreEqual("testUri://testUri", injectedWebRTCInstance->authentication.authority_uri.c_str());
 			Assert::AreEqual("00000000-0000-0000-0000-000000000000", injectedWebRTCInstance->authentication.client_id.c_str());
@@ -74,8 +74,8 @@ namespace ConfigParserTests
 			Assert::AreEqual("", defaultWebRTCInstance->turn_server.username.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->turn_server.password.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->server_uri.c_str());
-			Assert::IsTrue(((uint16_t)0) == defaultWebRTCInstance->port);
-			Assert::IsTrue(((uint32_t)0) == defaultWebRTCInstance->heartbeat);
+			Assert::AreEqual(((uint16_t)0), defaultWebRTCInstance->port);
+			Assert::AreEqual(((uint32_t)0), defaultWebRTCInstance->heartbeat);
 			Assert::AreEqual("", defaultWebRTCInstance->stun_server.uri.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->authentication.authority_uri.c_str());
 			Assert::AreEqual("", defaultWebRTCInstance->authentication.client_id.c_str());
@@ -91,18 +91,18 @@ namespace ConfigParserTests
 			auto defaultServerInstance = Object<ServerConfig>::Get<1>();
 
 			// should be parsed from disk (see serverConfig.json in the test directory)
-			Assert::IsTrue(((uint32_t)1234) == injectedServerInstance->server_config.height);
+			Assert::AreEqual(((uint32_t)1234), injectedServerInstance->server_config.height);
 			Assert::AreEqual(true, injectedServerInstance->server_config.system_service);
-			Assert::IsTrue(((uint32_t)5678) == injectedServerInstance->server_config.width);
+			Assert::AreEqual(((uint32_t)5678), injectedServerInstance->server_config.width);
 			Assert::AreEqual(L"test", injectedServerInstance->service_config.display_name.c_str());
 			Assert::AreEqual(L"test", injectedServerInstance->service_config.name.c_str());
 			Assert::AreEqual(L"test\\test", injectedServerInstance->service_config.service_account.c_str());
 			Assert::AreEqual(L"test", injectedServerInstance->service_config.service_password.c_str());
 
 			// should be default initialized
-			Assert::IsTrue(((uint32_t)0) == defaultServerInstance->server_config.height);
+			Assert::AreEqual(((uint32_t)0), defaultServerInstance->server_config.height);
 			Assert::AreEqual(false, defaultServerInstance->server_config.system_service);
-			Assert::IsTrue(((uint32_t)0) == defaultServerInstance->server_config.width);
+			Assert::AreEqual(((uint32_t)0), defaultServerInstance->server_config.width);
 			Assert::AreEqual(L"", defaultServerInstance->service_config.display_name.c_str());
 			Assert::AreEqual(L"", defaultServerInstance->service_config.name.c_str());
 			Assert::AreEqual(L"", defaultServerInstance->service_config.service_account.c_str());

--- a/Samples/Server/NativeServersUnitTests/NativeServersTests.cpp
+++ b/Samples/Server/NativeServersUnitTests/NativeServersTests.cpp
@@ -26,10 +26,10 @@ namespace NativeServersUnitTests
 			auto encoder = new H264EncoderImpl(cricket::VideoCodec("H264"));
 			VideoCodec codec_settings;
 			SetDefaultCodecSettings(&codec_settings);
-			Assert::IsTrue(encoder->InitEncode(&codec_settings, kNumCores, kMaxPayloadSize) == WEBRTC_VIDEO_CODEC_OK);
+			Assert::AreEqual(WEBRTC_VIDEO_CODEC_OK, encoder->InitEncode(&codec_settings, kNumCores, kMaxPayloadSize));
 
 			// Test correct release of encoder
-			Assert::IsTrue(encoder->Release() == WEBRTC_VIDEO_CODEC_OK);
+			Assert::AreEqual(WEBRTC_VIDEO_CODEC_OK, encoder->Release());
 			delete encoder;
 		}
 
@@ -233,7 +233,7 @@ namespace NativeServersUnitTests
 			h264TestImpl->input_frame_.get()->set_frame_buffer(rgbBuffer);
 
 			// Encode frame
-			Assert::IsTrue(h264TestImpl->encoder_->Encode(*h264TestImpl->input_frame_, nullptr, nullptr) == WEBRTC_VIDEO_CODEC_OK);
+			Assert::AreEqual(WEBRTC_VIDEO_CODEC_OK, h264TestImpl->encoder_->Encode(*h264TestImpl->input_frame_, nullptr, nullptr));
 			EncodedImage encoded_frame;
 
 			// Extract encoded_frame from the encoder
@@ -244,7 +244,7 @@ namespace NativeServersUnitTests
 			Assert::IsTrue(encoded_frame._length > 0);
 
 			// Test correct release of encoder
-			Assert::IsTrue(h264TestImpl->encoder_->Release() == WEBRTC_VIDEO_CODEC_OK);
+			Assert::AreEqual(WEBRTC_VIDEO_CODEC_OK, h264TestImpl->encoder_->Release());
 
 			delete[] rgbBuffer;
 			rgbBuffer = NULL;


### PR DESCRIPTION
## Checklist
***This checklist is used to make sure that common guidelines for a pull request are followed.***

- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] If applicable, the code is properly documented.
- [x] The code builds without any errors.
- [x] All unit and integration tests pass.

## Description
***Please add an informative description that covers the changes made by the pull request.***

When using `Assert::IsTrue(a == b)` as opposed to `Assert::AreEqual(a, b)`, you get an "Assert failed" message instead of "Expected: <aValue> Actual: <bValue>". The latter is generally preferable.

## Related Issues and PRs
***Please provide a reference to an [existing issue](https://github.com/CatalystCode/3dtoolkit/issues) and any related pull requests.***

Minor fix, no issues reported.