### PR TITLE
Send Turn Server info to Client on connection

### DIFF
--- a/Plugins/NativeServerPlugin/inc/peer_conductor.h
+++ b/Plugins/NativeServerPlugin/inc/peer_conductor.h
@@ -125,4 +125,9 @@ private:
 	// Names used for a SessionDescription JSON object.
 	const char* kSessionDescriptionTypeName = "type";
 	const char* kSessionDescriptionSdpName = "sdp";
+
+	// Credentials for Turn Server.
+	const char* kTurnServerUri = "uri";
+	const char* kTurnServerUsername = "username";
+	const char* kTurnServerPassword = "password";
 };

--- a/Plugins/NativeServerPlugin/src/peer_conductor.cpp
+++ b/Plugins/NativeServerPlugin/src/peer_conductor.cpp
@@ -69,6 +69,9 @@ void PeerConductor::OnSuccess(SessionDescriptionInterface* desc)
 		Json::Value jmessage;
 		jmessage[kSessionDescriptionTypeName] = desc->type();
 		jmessage[kSessionDescriptionSdpName] = sdp;
+		jmessage[kTurnServerUri] = webrtc_config_->turn_server.uri;
+		jmessage[kTurnServerUsername] = webrtc_config_->turn_server.username;
+		jmessage[kTurnServerPassword] = webrtc_config_->turn_server.password;
 
 		string message = writer.write(jmessage);
 

--- a/Samples/Client/DirectxWin32/src/conductor.cpp
+++ b/Samples/Client/DirectxWin32/src/conductor.cpp
@@ -412,11 +412,6 @@ void Conductor::OnMessageFromPeer(int peer_id, const std::string& message)
 		}
 		else if (type == "offer")
 		{
-			/*
-			This assumes that the list of servers is EMPTY.
-			TODO: check for servers? update existing turn server?
-			*/
-
 			// Parse Turn server credentials from offer.
 			std::string turn_username, turn_password, turn_uri;
 

--- a/Samples/Client/WebClient/README.md
+++ b/Samples/Client/WebClient/README.md
@@ -10,7 +10,7 @@ $ npm install
 
 ## 3DStreamingToolkit JavaScript Library
 
-The WebClient sample consumes a universal JavaScript plugin that is downloaded using npm. The source code can be found [here](https://github.com/CatalystCode/js-3dtoolkit). 
+The WebClient sample consumes a universal JavaScript plugin that is downloaded using npm. The source code can be found [here](https://github.com/3DStreamingToolkit/js-3dstk). 
 
 This library is responsible for connecting to the signaling server, exposing the data channel, connecting/disconnection to peers and handling the SDP offer between peers. By default, the library will request H264 video encoding when connecting to a peer. This is required for the low latency scenarios enabled by this toolkit.
 
@@ -21,8 +21,18 @@ To connect to a specific signaling server, you need to modify the value inside `
  var defaultSignalingServerUrl = 'http://localhost:3001'
 ```
 
-In case your scenario requires VPN/Proxy networks, you need to specify a turn server inside `app.js`:
-```  
+In case your scenario requires VPN/Proxy networks, you have two options to setup the configuration file:
+1. The js-3dstk library is capable of retriving the TURN credentials automatically from the server. In order to enable this feature, simply enable the following flag inside `app.js`:
+```
+  // Use this switch to determing whether Turn
+  // server credentials are parsed from sever
+  // connection offer, or declared here in config.
+  var parseTurnFromOffer = true;
+```
+2. You can also manually include the TURN server url and credentials inside `app.js`:
+<pre>
+  var parseTurnFromOffer = <b>false</b>;
+
   var pcConfigTURNStatic = {
     'iceServers': [{
         'urls': 'turn server goes here',
@@ -35,6 +45,11 @@ In case your scenario requires VPN/Proxy networks, you need to specify a turn se
     }],
     'iceTransportPolicy': 'relay'
   };
+</pre>
+
+If no VPN/Proxy networks are required, simply change the line 87 inside `app.js` with the code below:
+```
+   var pcConfig = pcConfigSTUNStatic;
 ```
 
 For more information read the [TURN-Service wiki](https://github.com/CatalystCode/3DStreamingToolkit/wiki/TURN-Service) and [sample implementation configuration files](https://github.com/CatalystCode/3DStreamingToolkit/wiki/JSON-Config-Files).
@@ -51,9 +66,9 @@ $ http-server
 Once the config settings are changed, the client will require a server to connect to. In this toolkit, we have a few [Sample Servers](https://github.com/CatalystCode/3DStreamingToolkit/tree/master/Samples/Server). 
 
 When both the client and server are connected to the same signaling server, they will appear in the peer list. 
-![capture2](https://user-images.githubusercontent.com/10086264/33888334-64db4d18-df55-11e7-830a-174b9049cceb.PNG)
+![image](https://user-images.githubusercontent.com/10086264/41976434-229ea2e8-79eb-11e8-9d89-82e7d374702f.png)
 
 You can initiate the connection using the client or server, simply select the peer from the list and press join. That will start the video streaming and you can use Click+Drag to rotate the camera or CTRL+Drag to move the camera. 
-![webclient](https://user-images.githubusercontent.com/10086264/33888182-fcf9e236-df54-11e7-9eac-0ba8f50cf0a4.PNG)
+![image2](https://user-images.githubusercontent.com/10086264/41976864-0830f1bc-79ec-11e8-884f-456ce0edee36.png)
 
 

--- a/Samples/Client/WebClient/app.js
+++ b/Samples/Client/WebClient/app.js
@@ -2,9 +2,20 @@ $(function(){
 
   URL = window.webkitURL || window.URL;
 
+  // Use this switch to determing whether Turn
+  // server credentials are parsed from sever
+  // connection offer, or declared here in config.
+  var parseTurnFromOffer = true;
+
+  // This config is used when parsing Turn credentials
+  var pcConfigNone = {
+    'iceServers': [],
+    'iceTransportPolicy': 'relay'
+  }
+
   // Using this config if you require a TURN server for VPN/Proxy networks. 
   // See https://github.com/CatalystCode/3dtoolkit/wiki/TURN-Service  
-  var pcConfigTURNStatic = {
+  var pcConfigStatic = {
     'iceServers': [{
         'urls': 'turn server goes here',
         'username': 'username goes here',
@@ -72,8 +83,8 @@ $(function(){
   };
   var accessToken;
 
-  // use pcConfigTURNStatic for VPN/Proxy networks. 
-  var pcConfig = pcConfigSTUNStatic;
+  // use pcConfigStatic if not parsing, otherwise empty 
+  var pcConfig = parseTurnFromOffer ? pcConfigNone : pcConfigStatic;
 
   RTCPeerConnection = window.mozRTCPeerConnection || window.webkitRTCPeerConnection || RTCPeerConnection;
   RTCSessionDescription = window.mozRTCSessionDescription || window.RTCSessionDescription || RTCSessionDescription;
@@ -256,7 +267,7 @@ $(function(){
 
         streamingClient = new ThreeDToolkit.ThreeDStreamingClient({
           'serverUrl': server,
-          'peerConnectionConfig': pcConfigStatic
+          'peerConnectionConfig': pcConfig
         }, {
           RTCPeerConnection: window.mozRTCPeerConnection || window.webkitRTCPeerConnection,
           RTCSessionDescription: window.mozRTCSessionDescription || window.RTCSessionDescription,

--- a/Samples/Client/WebClient/app.js
+++ b/Samples/Client/WebClient/app.js
@@ -265,7 +265,7 @@ $(function(){
         document.getElementById('disconnect').style.display = 'block';
         document.getElementById('renderers').style.display = 'block';
 
-        streamingClient = new ThreeDToolkit.ThreeDStreamingClient({
+        streamingClient = new ThreeDSToolkit.ThreeDStreamingClient({
           'serverUrl': server,
           'peerConnectionConfig': pcConfig
         }, {

--- a/Samples/Client/WebClient/app.js
+++ b/Samples/Client/WebClient/app.js
@@ -14,7 +14,7 @@ $(function(){
   }
 
   // Using this config if you require a TURN server for VPN/Proxy networks. 
-  // See https://github.com/CatalystCode/3dtoolkit/wiki/TURN-Service  
+  // See https://github.com/CatalystCode/3DStreamingToolkit/wiki/TURN-Service  
   var pcConfigStatic = {
     'iceServers': [{
         'urls': 'turn server goes here',
@@ -265,7 +265,7 @@ $(function(){
         document.getElementById('disconnect').style.display = 'block';
         document.getElementById('renderers').style.display = 'block';
 
-        streamingClient = new ThreeDSToolkit.ThreeDStreamingClient({
+        streamingClient = new ThreeDSTK.ThreeDStreamingClient({
           'serverUrl': server,
           'peerConnectionConfig': pcConfig
         }, {

--- a/Samples/Client/WebClient/app.js
+++ b/Samples/Client/WebClient/app.js
@@ -83,7 +83,8 @@ $(function(){
   };
   var accessToken;
 
-  // use pcConfigStatic if not parsing, otherwise empty 
+  // use pcConfigStatic if not parsing, otherwise empty
+  // use pcConfigSTUNStatic if no VPN/Proxy networks are required
   var pcConfig = parseTurnFromOffer ? pcConfigNone : pcConfigStatic;
 
   RTCPeerConnection = window.mozRTCPeerConnection || window.webkitRTCPeerConnection || RTCPeerConnection;

--- a/Samples/Client/WebClient/index.html
+++ b/Samples/Client/WebClient/index.html
@@ -100,7 +100,7 @@ html,body,h1,h2,h3,h4,h5 {font-family: "Open Sans", sans-serif}
 
     <script src="https://secure.aadcdn.microsoftonline-p.com/lib/0.1.1/js/msal.min.js"></script>
     <script src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.2.1.min.js"></script>
-    <script src="./node_modules/js-3dtoolkit/dist/js-3dtoolkit.min.js"></script>
+    <script src="./node_modules/js-3dstk/dist/js-3dstk.min.js"></script>
     <script src="./matrixmath.js"></script>
     <script src="./app.js"></script>
 </body>

--- a/Samples/Client/WebClient/index.html
+++ b/Samples/Client/WebClient/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>PeerConnection server test page</title>
+    <title>3D Streaming Toolkit PeerConnection server test page</title>
 </head>
 
 <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
@@ -18,13 +18,13 @@ html,body,h1,h2,h3,h4,h5 {font-family: "Open Sans", sans-serif}
 <div class="w3-top">
     <div class="w3-bar w3-theme-d2 w3-left-align w3-large">
       <a class="w3-bar-item w3-button w3-hide-medium w3-hide-large w3-right w3-padding-large w3-hover-white w3-large w3-theme-d2" href="javascript:void(0);" onclick="openNav()"><i class="fa fa-bars"></i></a>
-      <a href="#" class="w3-bar-item w3-button w3-padding-large w3-theme-d4"><i class="fa fa-home w3-margin-right"></i>3D Toolkit Web Client</a>
+      <a href="#" class="w3-bar-item w3-button w3-padding-large w3-theme-d4"><i class="fa fa-home w3-margin-right"></i>3D Streaming Toolkit Web Client</a>
      </div>
     </div>
 
     <!-- Navbar on small screens -->
     <div id="navDemo" class="w3-bar-block w3-theme-d2 w3-hide w3-hide-large w3-hide-medium w3-large">
-      <a href="#" class="w3-bar-item w3-button w3-padding-large">3D Toolkit Web Client</a>
+      <a href="#" class="w3-bar-item w3-button w3-padding-large">3D Streaming Toolkit Web Client</a>
     </div>
 
     <div id="container" class="w3-container w3-content" style="max-width:1400px;margin-top:80px">

--- a/Samples/Client/WebClient/package-lock.json
+++ b/Samples/Client/WebClient/package-lock.json
@@ -72,10 +72,10 @@
         "union": "0.4.6"
       }
     },
-    "js-3dtoolkit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/js-3dtoolkit/-/js-3dtoolkit-1.1.0.tgz",
-      "integrity": "sha512-i822R0rTUWoyCNQ0/2YdxV38bvo0NGrQxw7jHJSBN4UmIWPaXwWAztyW7+QkKM8QHegfU6A+OEBdU+WrOtMaWA==",
+    "js-3dstk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/js-3dstk/-/js-3dstk-1.2.0.tgz",
+      "integrity": "sha512-kgA4BA9NgvfQgu9HG4CImc0xgm1KXR9K1anoVBC4biEeGQ33PkOlQXP444n17CMqChJyyWzaRq9y53nzxsqaMA==",
       "requires": {
         "lodash": "4.17.5",
         "valid-url": "1.0.9"

--- a/Samples/Client/WebClient/package-lock.json
+++ b/Samples/Client/WebClient/package-lock.json
@@ -2,6 +2,7 @@
   "name": "webclient",
   "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "async": {
       "version": "1.5.2",
@@ -21,12 +22,21 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "ecstatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.1.1.tgz",
-      "integrity": "sha512-D9UcjcxDMMqjaQxC0mSsFh/IjJSdiZVPnHrhjHuKXlhLByk5QGGPX1GUIDIjRzhTq4UDCPYwWblw79VBEh3r1w=="
+      "integrity": "sha512-D9UcjcxDMMqjaQxC0mSsFh/IjJSdiZVPnHrhjHuKXlhLByk5QGGPX1GUIDIjRzhTq4UDCPYwWblw79VBEh3r1w==",
+      "requires": {
+        "he": "1.1.1",
+        "mime": "1.6.0",
+        "minimist": "1.2.0",
+        "url-join": "2.0.5"
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -41,17 +51,35 @@
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I="
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
     },
     "http-server": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w=="
+      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
+      "requires": {
+        "colors": "1.0.3",
+        "corser": "2.0.1",
+        "ecstatic": "3.1.1",
+        "http-proxy": "1.16.2",
+        "opener": "1.4.3",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.13",
+        "union": "0.4.6"
+      }
     },
     "js-3dtoolkit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/js-3dtoolkit/-/js-3dtoolkit-1.1.0.tgz",
-      "integrity": "sha512-i822R0rTUWoyCNQ0/2YdxV38bvo0NGrQxw7jHJSBN4UmIWPaXwWAztyW7+QkKM8QHegfU6A+OEBdU+WrOtMaWA=="
+      "integrity": "sha512-i822R0rTUWoyCNQ0/2YdxV38bvo0NGrQxw7jHJSBN4UmIWPaXwWAztyW7+QkKM8QHegfU6A+OEBdU+WrOtMaWA==",
+      "requires": {
+        "lodash": "4.17.5",
+        "valid-url": "1.0.9"
+      }
     },
     "lodash": {
       "version": "4.17.5",
@@ -72,6 +100,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -94,6 +125,10 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -105,7 +140,12 @@
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek="
+      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
+      }
     },
     "qs": {
       "version": "2.3.3",
@@ -120,7 +160,10 @@
     "union": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
-      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA="
+      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+      "requires": {
+        "qs": "2.3.3"
+      }
     },
     "url-join": {
       "version": "2.0.5",

--- a/Samples/Client/WebClient/package-lock.json
+++ b/Samples/Client/WebClient/package-lock.json
@@ -2,7 +2,6 @@
   "name": "webclient",
   "version": "1.0.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "async": {
       "version": "1.5.2",
@@ -20,28 +19,24 @@
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
     },
     "ecstatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.1.1.tgz",
-      "integrity": "sha512-D9UcjcxDMMqjaQxC0mSsFh/IjJSdiZVPnHrhjHuKXlhLByk5QGGPX1GUIDIjRzhTq4UDCPYwWblw79VBEh3r1w==",
-      "requires": {
-        "he": "1.1.1",
-        "mime": "1.6.0",
-        "minimist": "1.2.0",
-        "url-join": "2.0.5"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.2.0.tgz",
+      "integrity": "sha512-Goilx/2cfU9vvfQjgtNgc2VmJAD8CasQ6rZDqCd2u4Hsyd/qFET6nBf60jiHodevR3nl3IGzNKtrzPXWP88utQ=="
     },
     "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+    },
+    "follow-redirects": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA=="
     },
     "he": {
       "version": "1.1.1",
@@ -49,42 +44,24 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "http-proxy": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
-      }
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g=="
     },
     "http-server": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
-      "requires": {
-        "colors": "1.0.3",
-        "corser": "2.0.1",
-        "ecstatic": "3.1.1",
-        "http-proxy": "1.16.2",
-        "opener": "1.4.3",
-        "optimist": "0.6.1",
-        "portfinder": "1.0.13",
-        "union": "0.4.6"
-      }
+      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w=="
     },
     "js-3dstk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/js-3dstk/-/js-3dstk-1.2.0.tgz",
-      "integrity": "sha512-kgA4BA9NgvfQgu9HG4CImc0xgm1KXR9K1anoVBC4biEeGQ33PkOlQXP444n17CMqChJyyWzaRq9y53nzxsqaMA==",
-      "requires": {
-        "lodash": "4.17.5",
-        "valid-url": "1.0.9"
-      }
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/js-3dstk/-/js-3dstk-1.2.1.tgz",
+      "integrity": "sha512-Lmz3UZFQMfAJX6pM+rIFRqDHJLv2vzA/lQlaLnocDUdMLLnwriSbqycWt9O5sWQaoiksYiC4cU+ObPK2nsfyig=="
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "mime": {
       "version": "1.6.0",
@@ -100,9 +77,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -125,10 +99,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
-      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -141,10 +111,12 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-      "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+        }
       }
     },
     "qs": {
@@ -160,10 +132,7 @@
     "union": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
-      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
-      "requires": {
-        "qs": "2.3.3"
-      }
+      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA="
     },
     "url-join": {
       "version": "2.0.5",

--- a/Samples/Client/WebClient/package.json
+++ b/Samples/Client/WebClient/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "http-server": "^0.11.1",
-    "js-3dstk": "^1.2.0"
+    "js-3dstk": "^1.2.1"
   },
   "devDependencies": {},
   "author": "",

--- a/Samples/Client/WebClient/package.json
+++ b/Samples/Client/WebClient/package.json
@@ -4,8 +4,8 @@
   "description": "Web client sample for 3D Streaming Toolkit",
   "main": "app.js",
   "dependencies": {
-    "js-3dtoolkit": "^1.1.0",
-    "http-server": "^0.11.1"
+    "http-server": "^0.11.1",
+    "js-3dstk": "^1.2.0"
   },
   "devDependencies": {},
   "author": "",


### PR DESCRIPTION
## Description
The rendering server needs to pass the Turn Server credentials to the client when it creates the connection. `StreamingNativeServerPlugin` has an `OnSuccess` callback in its `peer_conductor.cpp` that is triggered when it has finished creating the offer; this callback has been altered to send the Turn Server credentials along with the session description.

This information is caught in `StreamingDirectxClient` by `OnMessageFromPeer`. If a message is received of type `offer`, parse the turn server config and push the information to the connection's list of servers. 

## Related Issues and PRs
Closes #262